### PR TITLE
Minor fixes / REPL interface improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ For more detailed information on contributing, check the [Contributing guideline
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GPL-3.0 License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ For more detailed information on contributing, check the [Contributing guideline
 
 ## License
 
-This project is licensed under the GPL-3.0 License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GNU General Public License v3.0 (GPL-3.0). See the [LICENSE](LICENSE) file for the full text of the license.

--- a/src/deducto/__main__.py
+++ b/src/deducto/__main__.py
@@ -4,4 +4,7 @@ def main():
     run_proof_session()
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except (KeyboardInterrupt, EOFError):
+        pass

--- a/src/deducto/__main__.py
+++ b/src/deducto/__main__.py
@@ -1,10 +1,10 @@
 from deducto.cli.session import run_proof_session
 
 def main():
-    run_proof_session()
-
-if __name__ == '__main__':
     try:
-        main()
+        run_proof_session()
     except (KeyboardInterrupt, EOFError):
         pass
+
+if __name__ == '__main__':
+    main()

--- a/src/deducto/cli/commands.py
+++ b/src/deducto/cli/commands.py
@@ -7,6 +7,7 @@ from deducto.cli.utils import all_paths, parse_path, resolve_path, set_path
 from deducto.core.proof import ProofStep
 from deducto.rules.apply import apply_rule, list_rules
 
+
 class CommandCompleter(Completer):
     def __init__(self, proof):
         self.proof = proof
@@ -114,6 +115,9 @@ def execute_command(cmd, proof, initial_steps):
         else:
             indices = [int(t) - 1 for t in targets]
             proof.try_rule(rule, indices)
+
+    else:
+        raise ValueError("Unknown command")
 
     if proof.goal and proof.steps[-1].result == proof.goal:
         return True

--- a/src/deducto/cli/session.py
+++ b/src/deducto/cli/session.py
@@ -15,15 +15,31 @@ def clear_line():
 def run_proof_session():
     variables = get_variables()
     clear_line()
-    print("Variables:", variables)
-    premises = get_premises(variables)
+    print("Variables:", ", ".join(variables))
+    while True:
+        try:
+            premises = get_premises(variables)
+            break
+        except SyntaxError as e:
+            print(f"Invalid syntax: {e}")
     clear_line()
-    print("Premises:")
-    for i, premise in enumerate(premises):
-        print(f"  {i + 1}. {premise}")
-    goal = get_goal(variables)
+    if premises:
+        print("Premises:")
+        for i, premise in enumerate(premises):
+            print(f"  {i + 1}. {premise}")
+    else:
+        print("No premises provided")
+    while True:
+        try:
+            goal = get_goal(variables)
+            break
+        except SyntaxError as e:
+            print(f"Invalid syntax: {e}")
     clear_line()
-    print("Goal:", goal)
+    if goal:
+        print("Goal:", goal)
+    else:
+        print("No goal provided")
 
     proof = ProofState(premises, goal)
     initial_steps = deepcopy(proof.steps)
@@ -35,11 +51,13 @@ def run_proof_session():
 
     while True:
         try:
-            cmd = session.prompt(">>> ").strip()
+            cmd = ""
+            while cmd == "":
+                cmd = session.prompt(">>> ").strip()
             if execute_command(cmd, proof, initial_steps):
                 break
             proof.show()
-        except EOFError:
+        except (KeyboardInterrupt, EOFError):
             if input("\nExit? (y/n): ").lower() == 'y':
                 break
         except Exception as e:

--- a/src/deducto/cli/session.py
+++ b/src/deducto/cli/session.py
@@ -8,18 +8,21 @@ from deducto.cli.utils import get_goal, get_premises, get_variables
 from deducto.core.proof import ProofState
 
 
-def run_proof_session():
-
-    variables = get_variables()
+def clear_line():
+    """Clears one line in the output"""
     print("\033[F\033[K", end="")
+
+def run_proof_session():
+    variables = get_variables()
+    clear_line()
     print("Variables:", variables)
     premises = get_premises(variables)
-    print("\033[F\033[K", end="")
+    clear_line()
     print("Premises:")
     for i, premise in enumerate(premises):
         print(f"  {i + 1}. {premise}")
     goal = get_goal(variables)
-    print("\033[F\033[K", end="")
+    clear_line()
     print("Goal:", goal)
 
     proof = ProofState(premises, goal)

--- a/src/deducto/cli/utils.py
+++ b/src/deducto/cli/utils.py
@@ -23,6 +23,7 @@ def get_goal(variables):
     goal = input_session.prompt("Goal: ").strip()
     # print("\033[F\033[K", end="")
     return parse(goal) if goal else None
+
 def resolve_path(expr, path):
     """Access a nested attribute path like ['left', 'right']"""
     for attr in path:

--- a/src/deducto/core/expr.py
+++ b/src/deducto/core/expr.py
@@ -31,80 +31,37 @@ class Not(Expr):
             return False
         return self.operand == other.operand
 
-class And(Expr):
+class BinaryOperation(Expr):
+    INFIX_SYMBOL = None # to define in the child classes
+
     def __init__(self, left, right):
         self.left = left
         self.right = right
 
     def __str__(self):
-        left_str = str(self.left) if isinstance(self.left, Var) or isinstance(self.left, Not) else f"({self.left})"
-        right_str = str(self.right) if isinstance(self.right, Var) or isinstance(self.right, Not) else f"({self.right})"
-        return f"{left_str} ∧ {right_str}"
+        left_str = str(self.left) if isinstance(self.left, (Var, Not)) else f"({self.left})"
+        right_str = str(self.right) if isinstance(self.right, (Var, Not)) else f"({self.right})"
+        return f"{left_str} {self.INFIX_SYMBOL} {right_str}"
 
     def __eq__(self, other):
-        if not isinstance(other, And):
+        if not isinstance(other, type(self)): # not the same type
             return False
         return self.left == other.left and self.right == other.right
 
-class Or(Expr):
-    def __init__(self, left, right):
-        self.left = left
-        self.right = right
+class And(BinaryOperation):
+    INFIX_SYMBOL = "∧"
 
-    def __str__(self):
-        left_str = str(self.left) if isinstance(self.left, Var) or isinstance(self.left, Not) else f"({self.left})"
-        right_str = str(self.right) if isinstance(self.right, Var) or isinstance(self.right, Not) else f"({self.right})"
-        return f"{left_str} ∨ {right_str}"
+class Or(BinaryOperation):
+    INFIX_SYMBOL = "∨"
 
-    def __eq__(self, other):
-        if not isinstance(other, Or):
-            return False
-        return self.left == other.left and self.right == other.right
+class Implies(BinaryOperation):
+    INFIX_SYMBOL = "→"
 
-class Implies(Expr):
-    def __init__(self, left, right):
-        self.left = left
-        self.right = right
+class Iff(BinaryOperation):
+    INFIX_SYMBOL = "↔"
 
-    def __str__(self):
-        left_str = str(self.left) if isinstance(self.left, Var) or isinstance(self.left, Not) else f"({self.left})"
-        right_str = str(self.right) if isinstance(self.right, Var) or isinstance(self.right, Not) else f"({self.right})"
-        return f"{left_str} → {right_str}"
-
-    def __eq__(self, other):
-        if not isinstance(other, Implies):
-            return False
-        return self.left == other.left and self.right == other.right
-
-class Iff(Expr):
-    def __init__(self, left, right):
-        self.left = left
-        self.right = right
-
-    def __str__(self):
-        left_str = str(self.left) if isinstance(self.left, Var) or isinstance(self.left, Not) else f"({self.left})"
-        right_str = str(self.right) if isinstance(self.right, Var) or isinstance(self.right, Not) else f"({self.right})"
-        return f"{left_str} ↔ {right_str}"
-
-    def __eq__(self, other):
-        if not isinstance(other, Iff):
-            return False
-        return self.left == other.left and self.right == other.right
-
-class Xor(Expr):
-    def __init__(self, left, right):
-        self.left = left
-        self.right = right
-
-    def __str__(self):
-        left_str = str(self.left) if isinstance(self.left, Var) or isinstance(self.left, Not) else f"({self.left})"
-        right_str = str(self.right) if isinstance(self.right, Var) or isinstance(self.right, Not) else f"({self.right})"
-        return f"{left_str} ⊕ {right_str}"
-
-    def __eq__(self, other):
-        if not isinstance(other, Xor):
-            return False
-        return self.left == other.left and self.right == other.right
+class Xor(BinaryOperation):
+    INFIX_SYMBOL = "⊕"
 
 class TrueExpr(Expr):
     def __init__(self):

--- a/src/deducto/rules/apply.py
+++ b/src/deducto/rules/apply.py
@@ -28,6 +28,7 @@ def apply_rule(rule: str, premises: List[Expr]) -> Expr:
     :param rule: The name of the rule to apply.
     :param premises: A list of premises (Expr objects).
     :return: The result of applying the rule, or None if not applicable.
+    :raises ValueError: If the rule given does not exist (or at least is not implemented)
     """
     rules = list_rules()
     # Check if the rule exists in the inference or equivalence modules
@@ -37,6 +38,9 @@ def apply_rule(rule: str, premises: List[Expr]) -> Expr:
         if rule_func:
             # Call the function with the premises
             return rule_func(*premises)
+
+    else:
+        raise ValueError(f"Rule '{rule}' does not exist")
 
 # def list_applicable_rules(premises: List[Expr], goal: Expr):
 #     suggestions = []


### PR DESCRIPTION
I first refactored some parts of the source:

 - I added a function `clear_line()` in `cli/session.py` to remove `print("\033[F\033[K", end="")`
   occurrences, thus making the code more readable
 - I added a base class `BinaryOperation` (in `core/expr.py`) that implements all the methods necessary for the
   binary connectives classes, which now all inherit from it. I made this change in order to remove code duplication
   in this file, and to make it more maintainable

REPL interface improvements:

 - Changed the replacement of the content entered in the "variables" prompt to a more readable
   syntax than raw Python list syntax
 - Changed the main prompt to allow empty (or blank) inputs to be ignored
 - Added a custom error message when the rule entered in the prompt is not implemented / does not exist
   (I modified the function `apply_rule(rule, premises)` in `rules/apply.py`)
 - Modified the behaviour when the syntax of the premises or the goal is not valid: instead of crashing
   with a `SyntaxError` like before, it now intercepts the exception, just prints it and asks for input again
 - Modified exception handling for unexpected inputs like `Control-D` or `Control-C`:
     - In the main prompt, I intercepted `KeyboardInterrupt` to have the same behaviour as `EOFError` handling
     - When a `KeyboardInterrupt` or `EOFError` is encountered *outside* of the main loop (at the beginning for example),
     it now causes the program to stop properly (without an error message)
 - Added an error message in the main interface when an unknown command is entered by the user (I changed
   `execute_command` function in `cli/commands.py`)

I also noticed that in the `README.md` file, the license seemed to be wrong (tell me if I am mistaken): the project was said to be licensed under the MIT license, but both the `LICENSE` and `CONTRIBUTING.md` files were saying it was licensed under the GNU GPLv3 License. I corrected this supposed error.

I ran the tests on my modified version (with both Python versions 3.13 and 3.8), and they were all successful.