### PR TITLE
Extend 'help' command

### DIFF
--- a/src/deducto/cli/commands.py
+++ b/src/deducto/cli/commands.py
@@ -5,7 +5,7 @@ from prompt_toolkit.document import Document
 
 from deducto.cli.utils import all_paths, parse_path, resolve_path, set_path
 from deducto.core.proof import ProofStep
-from deducto.rules.apply import list_rules
+from deducto.rules.apply import list_rules, get_rule_explanation
 from deducto.export.tex import export_tex
 from deducto.export.txt import export_txt
 from deducto.cli.parser import parse
@@ -60,6 +60,13 @@ class CommandCompleter(Completer):
                     completer = WordCompleter(step_refs, ignore_case=True)
                     yield from completer.get_completions(new_document, complete_event)
 
+                elif command == 'help':
+                    parts = remaining_text.split()
+                    if (
+                        len(parts) == 0 or (len(parts) == 1 and remaining_text[-1] != " ")
+                    ): # the rule is not or not fully entered
+                        completer = WordCompleter(self.rules, ignore_case=True)
+                        yield from completer.get_completions(new_document, complete_event)
 
         else:
             # Complete command names
@@ -97,19 +104,26 @@ def execute_command(cmd, proof, initial_steps):
             print(f"  {rule}")
         return False
 
-    if cmd.lower() == 'help':
-        print("Commands:")
-        print("  apply <rule> <target> - Apply a rule to the specified targets.")
-        print("  goal <goal> - Set the goal expression.")
-        print("  assume <premise> - Add an assumption.")
-        print("  list - List available rules.")
-        print("  exact - Check if the goal is reached.")
-        print("  undo - Undo the last step.")
-        print("  delete <n> - Delete step n.")
-        print("  reset - Reset to original assumptions.")
-        print("  export <format> <filename> - Export proof to specified format.")
-        print("  exit - Exit the session.")
-        print("  help - Show this help message.")
+    if cmd.lower().startswith('help'):
+        if len(parts) == 1:
+            print("Commands:")
+            print("  apply <rule> <target> - Apply a rule to the specified targets.")
+            print("  goal <goal> - Set the goal expression.")
+            print("  assume <premise> - Add an assumption.")
+            print("  list - List available rules.")
+            print("  exact - Check if the goal is reached.")
+            print("  undo - Undo the last step.")
+            print("  delete <n> - Delete step n.")
+            print("  reset - Reset to original assumptions.")
+            print("  export <format> <filename> - Export proof to specified format.")
+            print("  exit - Exit the session.")
+            print("  help - Show this help message.")
+            print("  help <rule> - Get help about a rule.")
+        elif len(parts) == 2:
+            rule = parts[1]
+            print(get_rule_explanation(rule))
+        else:
+            print("Usage: help or help <rule>")
         return False
 
     if cmd.lower() == 'undo':
@@ -194,7 +208,7 @@ def execute_command(cmd, proof, initial_steps):
         proof.try_rule(rule, targets)
 
     else:
-        raise ValueError("Unknown command")
+        raise ValueError(f"Unknown command '{cmd}'")
 
     if proof.goal and proof.steps[-1].result == proof.goal:
         return True

--- a/src/deducto/cli/session.py
+++ b/src/deducto/cli/session.py
@@ -49,6 +49,8 @@ def run_proof_session():
     session = PromptSession(completer=completer)
 
     print("Commands: apply <rule> <targets>, undo, delete <n>, reset, exit")
+    print("For help about the commands, enter: help")
+    print("For help about a rule, enter: help <rule>")
 
     while True:
         try:

--- a/src/deducto/rules/apply.py
+++ b/src/deducto/rules/apply.py
@@ -66,6 +66,24 @@ def apply_rule(rule: str, premises: List[Expr]) -> Expr:
 #                 suggestions.append(("iff_elim_right", [i]))
 #     return suggestions
 
+def get_rule_explanation(rule: str) -> str:
+    """
+    Get the explanation (docstring) of the rule given
+    ---
+    :param rule: The name of the rule
+    :return: The docstring of the rule
+    :raises ValueError: If the rule given does not exist (or at least is not implemented)
+    """
+    rules = list_rules()
+    # Check if the rule exists in the inference or equivalence modules
+    if rule in rules:
+        # Get the function object for the rule
+        rule_func = getattr(inference, rule, None) or getattr(equivalence, rule, None)
+        return rule_func.__doc__
+
+    else:
+        raise ValueError(f"Rule '{rule}' does not exist")
+
 if __name__ == '__main__':
     from deducto.parser import parse
     from copy import deepcopy

--- a/src/deducto/rules/equivalence.py
+++ b/src/deducto/rules/equivalence.py
@@ -1,5 +1,6 @@
 from deducto.core.expr import *
 
+
 def commutative_and(expr: And) -> And:
     """
     And(a, b) = And(b, a)
@@ -7,7 +8,6 @@ def commutative_and(expr: And) -> And:
     if not isinstance(expr, And):
         raise TypeError("Expected an instance of And")
     return And(expr.right, expr.left)
-
 
 def associative_and(expr: And) -> And:
     """
@@ -18,7 +18,7 @@ def associative_and(expr: And) -> And:
     if not isinstance(expr.left, And):
         raise TypeError("Expected the left operand to be an instance of And")
     return And(expr.left.left, And(expr.left.right, expr.right))
-    
+
 def commutative_or(expr: Or) -> Or:
     """
     Or(a, b) = Or(b, a)
@@ -128,6 +128,8 @@ def negation(expr: Not) -> Expr:
     """
     if not isinstance(expr, Not):
         raise TypeError("Expected an instance of Not")
+    if not isinstance(expr.negated, Not):
+        raise TypeError("Expected double negation")
     return expr.negated.negated
 
 def identity_or(expr: Or) -> Expr:

--- a/src/deducto/rules/inference.py
+++ b/src/deducto/rules/inference.py
@@ -3,7 +3,7 @@ from deducto.core.expr import *
 def modus_ponens(implication: Implies, premise: Expr):
     """
     premise: P
-    implication: P -> Q
+    implication: P → Q
     conclusion: Q
     """
     if not isinstance(implication, Implies):
@@ -14,9 +14,9 @@ def modus_ponens(implication: Implies, premise: Expr):
 
 def modus_tollens(implication: Implies, negation: Not):
     """
-    negation: not Q
-    implication: P -> Q
-    conclusion: not P
+    negation: ¬Q
+    implication: P → Q
+    conclusion: ¬P
     """
     if not isinstance(implication, Implies):
         raise TypeError("Invalid type for modus tollens: Expected Implies for implication")
@@ -28,9 +28,9 @@ def modus_tollens(implication: Implies, negation: Not):
 
 def hypothetical_syllogism(implication1: Implies, implication2: Implies):
     """
-    implication1: P -> Q
-    implication2: Q -> R
-    conclusion: P -> R
+    implication1: P → Q
+    implication2: Q → R
+    conclusion: P → R
     """
     if not isinstance(implication1, Implies):
         raise TypeError("Invalid type for hypothetical syllogism: Expected Implies for implication1")
@@ -42,8 +42,8 @@ def hypothetical_syllogism(implication1: Implies, implication2: Implies):
 
 def disjunctive_syllogism(disjunction: Or, negation: Not):
     """
-    disjunction: P or Q
-    negation: not P
+    disjunction: P ∨ Q
+    negation: ¬P
     conclusion: Q
     """
     if not isinstance(disjunction, Or):
@@ -57,13 +57,13 @@ def disjunctive_syllogism(disjunction: Or, negation: Not):
 def addition(premise: Expr, antecedent: Expr):
     """
     premise: P
-    conclusion: P or Q
+    conclusion: P ∨ Q
     """
     return Or(premise, antecedent)
 
 def simplification(conjunction: And):
     """
-    conjunction: P and Q
+    conjunction: P ∧ Q
     conclusion: P
     """
     if not isinstance(conjunction, And):
@@ -74,14 +74,14 @@ def conjunction(antecedent: Expr, consequent: Expr):
     """
     antecedent: P
     consequent: Q
-    conclusion: P and Q
+    conclusion: P ∧ Q
     """
     return And(antecedent, consequent)
 
 def resolution(disjunction1: Or, disjunction2: Or):
     """
-    disjunction1: P or Q
-    disjunction2: not P or R
+    disjunction1: P ∨ Q
+    disjunction2: ¬P ∨ R
     """
     if not isinstance(disjunction1, Or):
         raise TypeError("Invalid type for resolution: Expected Or for disjunction1")


### PR DESCRIPTION
I extended the 'help' command to also get help about logical rules, with the syntax `help <rule>`. I modified in consequence the completion, the base `help` message, as well as the message displayed at the beginning or the interface.

To do that, I implemented `get_rule_explanation(rule: str)` in `rules/apply` that gets the docstring of the function implementing the rule (using the \_\_doc\_\_ special attribute).

I also fixed the rule `negation`, which lacked an error message when the input is a negation but not a double negation.

Finally, I changed the docstrings in `rules/inference`: I replaced the plain text logical operators with unicode symbols, for more clarity when using the `help <rule>` command.